### PR TITLE
eBook conversion - fixed problems with chapter numbers and book intros

### DIFF
--- a/eBooks/css/ebible.css
+++ b/eBooks/css/ebible.css
@@ -16,7 +16,7 @@
   padding-left:3em;
 }
 .x-indent-0 {
-	margin-left: 0;	
+	margin-left: 0;
 }
 .x-indent-1 {
 	margin-left: 1.5em;	
@@ -61,6 +61,10 @@ p {
 	text-indent: 0
 }
 
+.first-line {
+	text-indent: 0
+}
+
 .canonical {
   font-style:italic;
 }
@@ -77,7 +81,8 @@ p {
 .x-chapter-number {
   font-size: 3em; 
   float: left; 
-  margin-right: 5px; 
+  margin-right: 5px;
+  text-indent: 0  
 }
 
 .x-introduction {


### PR DESCRIPTION
Fix for a problem where chapter/Psalm numbers were not being generated
where a chapter/Psalm starts with a poetic line. The layout of initial
poetic lines next to chapter/Psalm numbers has been improved. There is
also a fix for a problem which could result in book introductions not
being written.