### PR TITLE
Further footnote fixes in eBook conversion

### DIFF
--- a/eBooks/OSIS-Input/footnote.py
+++ b/eBooks/OSIS-Input/footnote.py
@@ -14,6 +14,7 @@ class BookFootnotes:
         self._epub3 = epub3
         self._footnotes = []
         self._count = 0
+        self._buffer= ''
         
     def reinit(self):
         del self._footnotes[:]
@@ -23,15 +24,24 @@ class BookFootnotes:
         self._count+= 1
         noteRef = '%s%d' % (book, self._count)
         self._footnotes.append(Footnote(noteRef, verse))
+        self._footnotes[self._count-1].content = self._buffer
         return self._count
         
     def addFootnoteText(self, text):
         # Deal with verse numbers supplied as "[nn]"
         text = re.sub(r'\[([0-9]+)\]\s*', r'<sup>\1</sup>', text)
-        self._footnotes[self._count-1].content += text
+        try:
+            self._footnotes[self._count-1].content += text
+        except IndexError:
+            # This may be a tag occurring before footnote text or reference has been written
+            # Keep text until the footnote is properly started
+            self._buffer += text
         
     def changeVerseId(self, vId):
         self._footnotes[self._count-1].verse = vId
+        
+    def footnoteComplete(self):
+        self._buffer=''
         
     def writeFootnotes(self):
         count = 0

--- a/eBooks/OSIS-Input/osis.py
+++ b/eBooks/OSIS-Input/osis.py
@@ -222,6 +222,7 @@ class OsisHandler(handler.ContentHandler):
         elif name == 'note':
             if self._inFootnote:
                 self._inFootnote = False
+                self._footnotes.footnoteComplete()
             else:
                 self._ignoreText = False
             
@@ -396,7 +397,7 @@ class OsisHandler(handler.ContentHandler):
                     # Ensure testament title is written
                     if self._firstBook and not self._groupHtmlOpen and self._groupTitle != '':
                         self._openGroupHtml()
-                        
+                    
                     self._openBookHtml()
 
                     if self._bookTitleFound or not self._context.config.bookTitlesInOSIS:
@@ -772,6 +773,9 @@ class OsisHandler(handler.ContentHandler):
                 
     def _openGroupHtml(self):
         if not self._groupHtmlOpen:
+            if self._bibleHtmlOpen:
+                # Write out any footnotes in the preceding Bible introduction
+                self._footnotes.writeFootnotes()
             groupNumber = self._docStructure.groupNumber
             htmlName = 'group%d' % groupNumber
             self._htmlWriter.open(htmlName)
@@ -781,6 +785,10 @@ class OsisHandler(handler.ContentHandler):
                 self._htmlWriter.write('<h1>%s</h1>\n' % self._groupTitle)
                 
     def _openBookHtml(self):
+        if self._groupHtmlOpen or self._bibleHtmlOpen:
+            # Write out any footnotes in the Bible or Testament introduction
+            self._footnotes.writeFootnotes()
+
         bookId = self._docStructure.bookId
         self._htmlWriter.open(bookId)
         self._groupHtmlOpen = False


### PR DESCRIPTION
A fix has been applied to the eBook conversion which handles a tag other
than <reference> preceding the text within a footnote. A further fix has
been applied to handle footnotes in Bible and Testament introductions.