### PR TITLE
eBook conversion: Fixes for testament intro problems

### DIFF
--- a/eBooks/OSIS-Input/structure.py
+++ b/eBooks/OSIS-Input/structure.py
@@ -3,7 +3,8 @@ class DocStructure:
     GROUP = 1
     BOOK = 2
     SECTION = 3
-    OTHER = 4
+    INTRO = 4
+    OTHER = 5
     IGNORED = 0
     ERROR = -1
     
@@ -50,6 +51,11 @@ class DocStructure:
         self.divStack.append(self.SECTION)
         self.refStack.append(ref)
         self.inSection = True
+        return True
+    
+    def startIntro(self):
+        self.divStack.append(self.INTRO)
+        self.refStack.append('')
         return True
     
     def otherDiv(self):

--- a/eBooks/OSIS-Input/writer.py
+++ b/eBooks/OSIS-Input/writer.py
@@ -28,9 +28,10 @@ class HtmlWriter:
             self._fh.write(str)
     
     def close(self):
-        self._writeFooter()
-        self._fh.close()
-        self._fh = None
+        if self._fh is not None:
+            self._writeFooter()
+            self._fh.close()
+            self._fh = None
     
     def closeAndRemove(self):
         self._fh.close()

--- a/eBooks/osis2ebook.pl
+++ b/eBooks/osis2ebook.pl
@@ -131,7 +131,7 @@ $foundgroup = 0;
 
 foreach $line (<COMF>) {
   $line = lc $line;
-  if ($line =~ /^group\d=/) {
+  if ($line =~ /^group\d\s*=/) {
     #Testament headings used
 	$COMMAND .= " --level1-toc //h:h1 --level2-toc //h:h2 --level3-toc //*[\@chapter]/\@chapter";
 	$foundgroup = 1;


### PR DESCRIPTION
Fixes for problems associated with testament introductions outside
books, the most serious of which was failure to include the introduction
in the output. Also fixed a problem where specifying a testament title
in convert.txt resulted in an incorrectly generated table of contents if
there was as space between "Group<n>" and the following "=". Fixed a
further problem where a crash was caused if the last book group in the
OSIS file was empty.